### PR TITLE
fix: `iroh provide` is now `iroh start`

### DIFF
--- a/netsim/sims/integration/derper.json
+++ b/netsim/sims/integration/derper.json
@@ -19,7 +19,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -60,7 +60,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "nat",
                     "wait": 10,
                     "connect": {
@@ -101,7 +101,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -142,7 +142,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh --keylog --cfg data/derp.config.toml start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "nat",
                     "wait": 10,
                     "connect": {

--- a/netsim/sims/integration/iroh.json
+++ b/netsim/sims/integration/iroh.json
@@ -9,7 +9,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -39,7 +39,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -68,7 +68,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -97,7 +97,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1MB.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1MB.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {

--- a/netsim/sims/iroh/iroh.json
+++ b/netsim/sims/iroh/iroh.json
@@ -8,7 +8,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -37,7 +37,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -66,7 +66,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -95,7 +95,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -124,7 +124,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -153,7 +153,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -182,7 +182,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -211,7 +211,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {

--- a/netsim/sims/iroh/iroh_200ms.json
+++ b/netsim/sims/iroh/iroh_200ms.json
@@ -8,7 +8,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -42,7 +42,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -76,7 +76,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -110,7 +110,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -144,7 +144,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -178,7 +178,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -212,7 +212,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -246,7 +246,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {

--- a/netsim/sims/iroh/iroh_20ms.json
+++ b/netsim/sims/iroh/iroh_20ms.json
@@ -8,7 +8,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -42,7 +42,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -76,7 +76,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -110,7 +110,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -144,7 +144,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -178,7 +178,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -212,7 +212,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -246,7 +246,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {

--- a/netsim/sims/lossy/iroh.json
+++ b/netsim/sims/lossy/iroh.json
@@ -8,7 +8,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -42,7 +42,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -76,7 +76,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -110,7 +110,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -144,7 +144,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -178,7 +178,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -212,7 +212,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -246,7 +246,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {

--- a/netsim/sims/standard/iroh.json
+++ b/netsim/sims/standard/iroh.json
@@ -8,7 +8,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -37,7 +37,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -66,7 +66,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -95,7 +95,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 1,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -124,7 +124,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -153,7 +153,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -182,7 +182,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {
@@ -211,7 +211,7 @@
                 {
                     "name": "iroh_srv",
                     "count": 2,
-                    "cmd": "./bins/iroh provide -a 0.0.0.0:4433 data/1G.bin",
+                    "cmd": "./bins/iroh start -a 0.0.0.0:4433 data/1G.bin",
                     "type": "public",
                     "wait": 10,
                     "connect": {


### PR DESCRIPTION
I think this is needed to have `netsim` pass after https://github.com/n0-computer/iroh/pull/1356 is merged.
@Arqu is there a good way to test this beforehand?