### PR TITLE
fix: full-cone NAT + link_up route restoration for holepunch testing

### DIFF
--- a/netsim/main.py
+++ b/netsim/main.py
@@ -545,6 +545,18 @@ def run_case(nodes, runner_id, prefix, args, debug=False, visualize=False):
     p_box, p_short_box = [], []
     temp_dirs = []
 
+    # Start tcpdump on NAT nodes to capture all UDP during test
+    for node in nodes:
+        if node["type"] in ("nat", "multi_nat"):
+            for i in range(int(node["count"])):
+                if node["type"] == "nat":
+                    nat_name = f'n_{node["name"]}{i}r{runner_id}'
+                elif node["type"] == "multi_nat":
+                    nat_name = f'n1_{node["name"]}{i}r{runner_id}'
+                nat_n = net.get(nat_name)
+                if nat_n:
+                    nat_n.cmd(f'timeout 30 tcpdump -l -i any -nn udp -c 200 > logs/{prefix}__{nat_name}__tcpdump.txt 2>&1 &')
+
     node_counts = {node["name"]: int(node["count"]) for node in nodes}
     node_ips = get_node_ips(net, nodes, runner_id)
     node_params = {}

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -144,9 +144,11 @@ except socket.timeout:
             with open(script_path, 'w') as sf:
                 sf.write(sim_script)
 
-            # Start tcpdump on both NATs to trace packets
-            h1_nat.cmd('timeout 8 tcpdump -i any -nn udp port 33333 > /tmp/tcpdump_nat1.txt 2>&1 &')
-            h2_nat.cmd('timeout 8 tcpdump -i any -nn udp port 33333 > /tmp/tcpdump_nat2.txt 2>&1 &')
+            # Start tcpdump on both NATs and both hosts
+            h1_nat.cmd('timeout 8 tcpdump -l -i any -nn udp port 33333 > /tmp/tcpdump.txt 2>&1 &')
+            h2_nat.cmd('timeout 8 tcpdump -l -i any -nn udp port 33333 > /tmp/tcpdump.txt 2>&1 &')
+            h1.cmd('timeout 8 tcpdump -l -i any -nn udp port 33333 > /tmp/tcpdump.txt 2>&1 &')
+            h2.cmd('timeout 8 tcpdump -l -i any -nn udp port 33333 > /tmp/tcpdump.txt 2>&1 &')
             time.sleep(0.3)
 
             h1.cmd(f'python3 {script_path} 33333 {h2_pub} H1 > /tmp/udp_sim_recv 2>&1 &')
@@ -158,12 +160,12 @@ except socket.timeout:
             f.write(f"  {h1_name} ({h1_pub}) -> {h2_pub}: {h1_got}\n")
             f.write(f"  {h2_name} ({h2_pub}) -> {h1_pub}: {h2_got}\n")
 
-            # Dump tcpdump captures
+            # Dump tcpdump captures (each node writes to /tmp/tcpdump.txt in its own ns)
             time.sleep(1)
-            nat1_cap = h1_nat.cmd('cat /tmp/tcpdump_nat1.txt 2>/dev/null').strip()
-            nat2_cap = h2_nat.cmd('cat /tmp/tcpdump_nat2.txt 2>/dev/null').strip()
-            f.write(f"\n{h1_nat_name} tcpdump (port 33333):\n{nat1_cap}\n")
-            f.write(f"\n{h2_nat_name} tcpdump (port 33333):\n{nat2_cap}\n")
+            for label, node in [(h1_nat_name, h1_nat), (h2_nat_name, h2_nat),
+                                (h1_name, h1), (h2_name, h2)]:
+                cap = node.cmd('cat /tmp/tcpdump.txt 2>/dev/null').strip()
+                f.write(f"\n{label} tcpdump (port 33333):\n{cap}\n")
 
             # Dump conntrack
             for nat_name, nat_n in [(h1_nat_name, h1_nat), (h2_nat_name, h2_nat)]:

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -144,6 +144,11 @@ except socket.timeout:
             with open(script_path, 'w') as sf:
                 sf.write(sim_script)
 
+            # Start tcpdump on both NATs to trace packets
+            h1_nat.cmd('timeout 8 tcpdump -i any -nn udp port 33333 > /tmp/tcpdump_nat1.txt 2>&1 &')
+            h2_nat.cmd('timeout 8 tcpdump -i any -nn udp port 33333 > /tmp/tcpdump_nat2.txt 2>&1 &')
+            time.sleep(0.3)
+
             h1.cmd(f'python3 {script_path} 33333 {h2_pub} H1 > /tmp/udp_sim_recv 2>&1 &')
             h2.cmd(f'python3 {script_path} 33333 {h1_pub} H2 > /tmp/udp_sim_recv 2>&1 &')
             time.sleep(5)
@@ -153,10 +158,17 @@ except socket.timeout:
             f.write(f"  {h1_name} ({h1_pub}) -> {h2_pub}: {h1_got}\n")
             f.write(f"  {h2_name} ({h2_pub}) -> {h1_pub}: {h2_got}\n")
 
-            # Dump NAT conntrack after tests
+            # Dump tcpdump captures
+            time.sleep(1)
+            nat1_cap = h1_nat.cmd('cat /tmp/tcpdump_nat1.txt 2>/dev/null').strip()
+            nat2_cap = h2_nat.cmd('cat /tmp/tcpdump_nat2.txt 2>/dev/null').strip()
+            f.write(f"\n{h1_nat_name} tcpdump (port 33333):\n{nat1_cap}\n")
+            f.write(f"\n{h2_nat_name} tcpdump (port 33333):\n{nat2_cap}\n")
+
+            # Dump conntrack
             for nat_name, nat_n in [(h1_nat_name, h1_nat), (h2_nat_name, h2_nat)]:
-                ct = nat_n.cmd('conntrack -L 2>/dev/null || cat /proc/net/nf_conntrack 2>/dev/null || echo no-conntrack').strip()
-                f.write(f"\n{nat_name} conntrack:\n{ct}\n")
+                ct = nat_n.cmd('cat /proc/net/nf_conntrack 2>/dev/null | grep 33333 || echo no-conntrack-entries').strip()
+                f.write(f"\n{nat_name} conntrack (port 33333):\n{ct}\n")
 
 
 def execute_action(net, node_name, action, runner_id):

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -38,6 +38,61 @@ def configure_multi_nat_hosts(net, nodes, runner_id):
                 n.cmd(f"ip addr add {second_ip} dev {second_intf}")
 
 
+def debug_network(net, nodes, runner_id):
+    """Dump network configuration for debugging NAT traversal issues."""
+    info("=== DEBUG: Network Configuration ===\n")
+    for node in nodes:
+        if node["type"] not in ("nat", "multi_nat"):
+            continue
+        for i in range(int(node["count"])):
+            # Debug the NAT node(s)
+            if node["type"] == "nat":
+                nat_name = f'n_{node["name"]}{i}r{runner_id}'
+                host_name = f'{node["name"]}_{i}_r{runner_id}'
+                for name in [nat_name, host_name]:
+                    n = net.get(name)
+                    if n:
+                        info(f"\n--- {name} ---\n")
+                        info(f"interfaces: {n.cmd('ip -4 addr show')}\n")
+                        info(f"routes: {n.cmd('ip route show')}\n")
+                        info(f"iptables nat: {n.cmd('iptables -t nat -L -n -v')}\n")
+                        info(f"iptables filter: {n.cmd('iptables -L FORWARD -n -v')}\n")
+                        info(f"conntrack: {n.cmd('conntrack -L 2>/dev/null || echo no-conntrack')}\n")
+            elif node["type"] == "multi_nat":
+                host_name = f'{node["name"]}_{i}_r{runner_id}'
+                nat1_name = f'n1_{node["name"]}{i}r{runner_id}'
+                nat2_name = f'n2_{node["name"]}{i}r{runner_id}'
+                for name in [nat1_name, nat2_name, host_name]:
+                    n = net.get(name)
+                    if n:
+                        info(f"\n--- {name} ---\n")
+                        info(f"interfaces: {n.cmd('ip -4 addr show')}\n")
+                        info(f"routes: {n.cmd('ip route show')}\n")
+                        info(f"iptables nat: {n.cmd('iptables -t nat -L -n -v')}\n")
+                        info(f"iptables filter: {n.cmd('iptables -L FORWARD -n -v')}\n")
+
+    # Test connectivity between hosts
+    info("\n=== DEBUG: Connectivity Test ===\n")
+    host_names = []
+    for node in nodes:
+        if node["type"] in ("nat", "multi_nat"):
+            for i in range(int(node["count"])):
+                host_names.append(f'{node["name"]}_{i}_r{runner_id}')
+    if len(host_names) >= 2:
+        h1 = net.get(host_names[0])
+        h2 = net.get(host_names[1])
+        if h1 and h2:
+            # Get public IPs by checking default route gateway
+            h1_gw = h1.cmd("ip route | grep default | awk '{print $3}'").strip()
+            h2_gw = h2.cmd("ip route | grep default | awk '{print $3}'").strip()
+            info(f"{host_names[0]} gateway: {h1_gw}\n")
+            info(f"{host_names[1]} gateway: {h2_gw}\n")
+            # Try pinging each other's gateways (public side of NAT)
+            info(f"{host_names[0]} ping relay: {h1.cmd('ping -c1 -W1 10.0.0.1')}\n")
+            info(f"{host_names[1]} ping relay: {h2.cmd('ping -c1 -W1 10.0.0.1')}\n")
+    info("=== END DEBUG ===\n")
+
+
 def execute_action(net, node_name, action, runner_id):
     """Execute a network action on a node."""
     n = net.get(node_name)
@@ -355,6 +410,7 @@ def get_node_ips(net, nodes, runner_id):
 
 def prep_net(net, nodes, prefix, sniff, runner_id):
     configure_multi_nat_hosts(net, nodes, runner_id)
+    debug_network(net, nodes, runner_id)
     sniffer = Sniffer(net=net, output="logs/" + prefix + ".pcap")
     ti = sniffer.get_topoinfo()
     info("Testing network connectivity")

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -241,7 +241,7 @@ def execute_action(net, node_name, action, runner_id):
             if host_ip:
                 # Gateway is .1 on the same subnet
                 gw_ip = ".".join(host_ip.split(".")[:3]) + ".1"
-                n.cmd(f"ip route replace default via {gw_ip}")
+                n.cmd(f"ip route replace default via {gw_ip} dev {intfs[intf_idx]}")
                 info(f"ACTION [{node_name}]: Brought up {intfs[intf_idx]}, restored route via {gw_ip}\n")
             else:
                 info(f"ACTION [{node_name}]: Brought up {intfs[intf_idx]}, no IP found to restore route\n")

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -40,57 +40,58 @@ def configure_multi_nat_hosts(net, nodes, runner_id):
 
 def debug_network(net, nodes, runner_id):
     """Dump network configuration for debugging NAT traversal issues."""
-    info("=== DEBUG: Network Configuration ===\n")
-    for node in nodes:
-        if node["type"] not in ("nat", "multi_nat"):
-            continue
-        for i in range(int(node["count"])):
-            # Debug the NAT node(s)
-            if node["type"] == "nat":
-                nat_name = f'n_{node["name"]}{i}r{runner_id}'
-                host_name = f'{node["name"]}_{i}_r{runner_id}'
-                for name in [nat_name, host_name]:
-                    n = net.get(name)
-                    if n:
-                        info(f"\n--- {name} ---\n")
-                        info(f"interfaces: {n.cmd('ip -4 addr show')}\n")
-                        info(f"routes: {n.cmd('ip route show')}\n")
-                        info(f"iptables nat: {n.cmd('iptables -t nat -L -n -v')}\n")
-                        info(f"iptables filter: {n.cmd('iptables -L FORWARD -n -v')}\n")
-                        info(f"conntrack: {n.cmd('conntrack -L 2>/dev/null || echo no-conntrack')}\n")
-            elif node["type"] == "multi_nat":
-                host_name = f'{node["name"]}_{i}_r{runner_id}'
-                nat1_name = f'n1_{node["name"]}{i}r{runner_id}'
-                nat2_name = f'n2_{node["name"]}{i}r{runner_id}'
-                for name in [nat1_name, nat2_name, host_name]:
-                    n = net.get(name)
-                    if n:
-                        info(f"\n--- {name} ---\n")
-                        info(f"interfaces: {n.cmd('ip -4 addr show')}\n")
-                        info(f"routes: {n.cmd('ip route show')}\n")
-                        info(f"iptables nat: {n.cmd('iptables -t nat -L -n -v')}\n")
-                        info(f"iptables filter: {n.cmd('iptables -L FORWARD -n -v')}\n")
-
-    # Test connectivity between hosts
-    info("\n=== DEBUG: Connectivity Test ===\n")
-    host_names = []
-    for node in nodes:
-        if node["type"] in ("nat", "multi_nat"):
+    with open("logs/debug_network.txt", "w") as f:
+        f.write("=== Network Configuration ===\n")
+        for node in nodes:
+            if node["type"] not in ("nat", "multi_nat"):
+                continue
             for i in range(int(node["count"])):
-                host_names.append(f'{node["name"]}_{i}_r{runner_id}')
-    if len(host_names) >= 2:
-        h1 = net.get(host_names[0])
-        h2 = net.get(host_names[1])
-        if h1 and h2:
-            # Get public IPs by checking default route gateway
-            h1_gw = h1.cmd("ip route | grep default | awk '{print $3}'").strip()
-            h2_gw = h2.cmd("ip route | grep default | awk '{print $3}'").strip()
-            info(f"{host_names[0]} gateway: {h1_gw}\n")
-            info(f"{host_names[1]} gateway: {h2_gw}\n")
-            # Try pinging each other's gateways (public side of NAT)
-            info(f"{host_names[0]} ping relay: {h1.cmd('ping -c1 -W1 10.0.0.1')}\n")
-            info(f"{host_names[1]} ping relay: {h2.cmd('ping -c1 -W1 10.0.0.1')}\n")
-    info("=== END DEBUG ===\n")
+                if node["type"] == "nat":
+                    nat_name = f'n_{node["name"]}{i}r{runner_id}'
+                    host_name = f'{node["name"]}_{i}_r{runner_id}'
+                    for name in [nat_name, host_name]:
+                        n = net.get(name)
+                        if n:
+                            f.write(f"\n--- {name} ---\n")
+                            f.write(f"ip addr:\n{n.cmd('ip -4 addr show')}\n")
+                            f.write(f"routes:\n{n.cmd('ip route show')}\n")
+                            f.write(f"iptables nat:\n{n.cmd('iptables -t nat -L -n -v')}\n")
+                            f.write(f"iptables forward:\n{n.cmd('iptables -L FORWARD -n -v')}\n")
+                elif node["type"] == "multi_nat":
+                    host_name = f'{node["name"]}_{i}_r{runner_id}'
+                    nat1_name = f'n1_{node["name"]}{i}r{runner_id}'
+                    nat2_name = f'n2_{node["name"]}{i}r{runner_id}'
+                    for name in [nat1_name, nat2_name, host_name]:
+                        n = net.get(name)
+                        if n:
+                            f.write(f"\n--- {name} ---\n")
+                            f.write(f"ip addr:\n{n.cmd('ip -4 addr show')}\n")
+                            f.write(f"routes:\n{n.cmd('ip route show')}\n")
+                            f.write(f"iptables nat:\n{n.cmd('iptables -t nat -L -n -v')}\n")
+                            f.write(f"iptables forward:\n{n.cmd('iptables -L FORWARD -n -v')}\n")
+
+        # Connectivity tests
+        f.write("\n=== Connectivity Tests ===\n")
+        all_hosts = []
+        for node in nodes:
+            for i in range(int(node["count"])):
+                name = f'{node["name"]}_{i}_r{runner_id}'
+                n = net.get(name)
+                if n:
+                    all_hosts.append((name, n))
+        for name, n in all_hosts:
+            f.write(f"\n{name} ping 10.0.0.1: {n.cmd('ping -c1 -W1 10.0.0.1')}\n")
+        # UDP connectivity test between NAT hosts
+        if len(all_hosts) >= 2:
+            h1_name, h1 = all_hosts[-2]
+            h2_name, h2 = all_hosts[-1]
+            # h2 listens, h1 sends
+            h2.cmd('timeout 2 nc -u -l -p 12345 > /tmp/udp_test 2>&1 &')
+            import time; time.sleep(0.1)
+            h1_out = h1.cmd('echo HELLO | nc -u -w1 10.0.0.1 12345 2>&1')
+            time.sleep(0.5)
+            h2_got = h2.cmd('cat /tmp/udp_test 2>/dev/null')
+            f.write(f"\nUDP test: {h1_name} -> 10.0.0.1:12345: sent={h1_out.strip()}, received={h2_got.strip()}\n")
 
 
 def execute_action(net, node_name, action, runner_id):

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -234,7 +234,17 @@ def execute_action(net, node_name, action, runner_id):
         intf_idx = action.get("interface", 0)
         if intf_idx < len(intfs):
             n.cmd(f"ip link set {intfs[intf_idx]} up")
-            info(f"ACTION [{node_name}]: Brought up {intfs[intf_idx]}\n")
+            # Restore the default route via the NAT gateway. When the interface
+            # went down, Linux removed the route. It's not automatically restored
+            # on link up. Derive the gateway from the host's IP on this interface.
+            host_ip = n.cmd(f"ip -4 addr show {intfs[intf_idx]} | grep -oP 'inet \\K[\\d.]+'").strip()
+            if host_ip:
+                # Gateway is .1 on the same subnet
+                gw_ip = ".".join(host_ip.split(".")[:3]) + ".1"
+                n.cmd(f"ip route replace default via {gw_ip}")
+                info(f"ACTION [{node_name}]: Brought up {intfs[intf_idx]}, restored route via {gw_ip}\n")
+            else:
+                info(f"ACTION [{node_name}]: Brought up {intfs[intf_idx]}, no IP found to restore route\n")
 
     elif action_type == "change_ip":
         intf_idx = action.get("interface", 0)

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -81,17 +81,66 @@ def debug_network(net, nodes, runner_id):
                     all_hosts.append((name, n))
         for name, n in all_hosts:
             f.write(f"\n{name} ping 10.0.0.1: {n.cmd('ping -c1 -W1 10.0.0.1')}\n")
-        # UDP connectivity test between NAT hosts
-        if len(all_hosts) >= 2:
-            h1_name, h1 = all_hosts[-2]
-            h2_name, h2 = all_hosts[-1]
-            # h2 listens, h1 sends
-            h2.cmd('timeout 2 nc -u -l -p 12345 > /tmp/udp_test 2>&1 &')
-            import time; time.sleep(0.1)
-            h1_out = h1.cmd('echo HELLO | nc -u -w1 10.0.0.1 12345 2>&1')
-            time.sleep(0.5)
-            h2_got = h2.cmd('cat /tmp/udp_test 2>/dev/null')
-            f.write(f"\nUDP test: {h1_name} -> 10.0.0.1:12345: sent={h1_out.strip()}, received={h2_got.strip()}\n")
+        # Get NAT public IPs
+        nat_nodes_info = []
+        for node in nodes:
+            if node["type"] == "nat":
+                for i in range(int(node["count"])):
+                    nat_name = f'n_{node["name"]}{i}r{runner_id}'
+                    host_name = f'{node["name"]}_{i}_r{runner_id}'
+                    nat_n = net.get(nat_name)
+                    host_n = net.get(host_name)
+                    if nat_n and host_n:
+                        # Get the NAT's public IP from its inet interface
+                        pub_ip = nat_n.cmd("ip -4 addr show | grep 10\\.0\\. | grep -oP 'inet \\K[^/]+'").strip()
+                        nat_nodes_info.append((host_name, host_n, pub_ip, nat_name, nat_n))
+            elif node["type"] == "multi_nat":
+                for i in range(int(node["count"])):
+                    nat1_name = f'n1_{node["name"]}{i}r{runner_id}'
+                    host_name = f'{node["name"]}_{i}_r{runner_id}'
+                    nat_n = net.get(nat1_name)
+                    host_n = net.get(host_name)
+                    if nat_n and host_n:
+                        pub_ip = nat_n.cmd("ip -4 addr show | grep 10\\.0\\. | grep -oP 'inet \\K[^/]+'").strip()
+                        nat_nodes_info.append((host_name, host_n, pub_ip, nat1_name, nat_n))
+
+        import time
+        if len(nat_nodes_info) >= 2:
+            h1_name, h1, h1_pub, h1_nat_name, h1_nat = nat_nodes_info[0]
+            h2_name, h2, h2_pub, h2_nat_name, h2_nat = nat_nodes_info[1]
+            f.write(f"\n{h1_name} behind {h1_nat_name} (pub: {h1_pub})\n")
+            f.write(f"{h2_name} behind {h2_nat_name} (pub: {h2_pub})\n")
+
+            # Test 1: Can h1 send UDP to h2's NAT public IP? (without hole punch)
+            h2_nat.cmd(f'timeout 2 tcpdump -i any -c 5 udp port 55555 -w /tmp/cap1.pcap &')
+            time.sleep(0.2)
+            h1.cmd(f'echo TEST1 | nc -u -w1 {h2_pub} 55555 2>&1')
+            time.sleep(1)
+            cap1 = h2_nat.cmd('tcpdump -r /tmp/cap1.pcap 2>/dev/null').strip()
+            f.write(f"\nTest 1: {h1_name} -> {h2_pub}:55555 (no hole punch)\n")
+            f.write(f"  tcpdump on {h2_nat_name}: {cap1}\n")
+
+            # Test 2: Simultaneous send - h1 sends to h2_pub, h2 sends to h1_pub
+            h1.cmd('rm -f /tmp/udp_sim_recv')
+            h2.cmd('rm -f /tmp/udp_sim_recv')
+            # Both listen
+            h1.cmd('timeout 3 python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.settimeout(2);print(s.recvfrom(100))" > /tmp/udp_sim_recv 2>&1 &')
+            h2.cmd('timeout 3 python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.settimeout(2);print(s.recvfrom(100))" > /tmp/udp_sim_recv 2>&1 &')
+            time.sleep(0.2)
+            # Both send simultaneously from port 44444
+            h1.cmd(f'python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.sendto(b\\\"FROM_H1\\\",(\\\"{h2_pub}\\\",44444))" &')
+            h2.cmd(f'python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.sendto(b\\\"FROM_H2\\\",(\\\"{h1_pub}\\\",44444))" &')
+            time.sleep(2)
+            h1_got = h1.cmd('cat /tmp/udp_sim_recv 2>/dev/null').strip()
+            h2_got = h2.cmd('cat /tmp/udp_sim_recv 2>/dev/null').strip()
+            f.write(f"\nTest 2: Simultaneous UDP (port 44444)\n")
+            f.write(f"  {h1_name} received: '{h1_got}'\n")
+            f.write(f"  {h2_name} received: '{h2_got}'\n")
+
+            # Dump NAT conntrack after tests
+            for nat_name, nat_n in [(h1_nat_name, h1_nat), (h2_nat_name, h2_nat)]:
+                ct = nat_n.cmd('conntrack -L 2>/dev/null || cat /proc/net/nf_conntrack 2>/dev/null || echo no-conntrack').strip()
+                f.write(f"\n{nat_name} conntrack:\n{ct}\n")
 
 
 def execute_action(net, node_name, action, runner_id):

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -151,6 +151,7 @@ except socket.timeout:
             h2.cmd('timeout 8 tcpdump -l -i any -nn udp port 33333 > /tmp/tcpdump.txt 2>&1 &')
             time.sleep(0.3)
 
+            # Test with SAME port (like our raw test)
             h1.cmd(f'python3 {script_path} 33333 {h2_pub} H1 > /tmp/udp_sim_recv 2>&1 &')
             h2.cmd(f'python3 {script_path} 33333 {h1_pub} H2 > /tmp/udp_sim_recv 2>&1 &')
             time.sleep(5)
@@ -159,6 +160,36 @@ except socket.timeout:
             f.write(f"\nTest 2: Simultaneous UDP hole punch (port 33333)\n")
             f.write(f"  {h1_name} ({h1_pub}) -> {h2_pub}: {h1_got}\n")
             f.write(f"  {h2_name} ({h2_pub}) -> {h1_pub}: {h2_got}\n")
+
+            # Test 3: Asymmetric ports (like iroh uses)
+            asym_script = '''
+import socket, time, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", int(sys.argv[1])))
+s.settimeout(3)
+s.sendto(b"ASYM_FROM_" + sys.argv[4].encode(), (sys.argv[2], int(sys.argv[3])))
+time.sleep(0.05)
+s.sendto(b"ASYM_FROM_" + sys.argv[4].encode(), (sys.argv[2], int(sys.argv[3])))
+try:
+    data, addr = s.recvfrom(100)
+    print(f"GOT: {data} from {addr}")
+except socket.timeout:
+    print("TIMEOUT: no data received")
+'''
+            asym_path = '/tmp/udp_asym.py'
+            with open(asym_path, 'w') as sf:
+                sf.write(asym_script)
+
+            # h1 binds 44444, sends to h2_pub:55555. h2 binds 55555, sends to h1_pub:44444.
+            h1.cmd(f'python3 {asym_path} 44444 {h2_pub} 55555 H1 > /tmp/udp_asym_recv 2>&1 &')
+            h2.cmd(f'python3 {asym_path} 55555 {h1_pub} 44444 H2 > /tmp/udp_asym_recv 2>&1 &')
+            time.sleep(5)
+            h1_asym = h1.cmd('cat /tmp/udp_asym_recv 2>/dev/null').strip()
+            h2_asym = h2.cmd('cat /tmp/udp_asym_recv 2>/dev/null').strip()
+            f.write(f"\nTest 3: Asymmetric ports (h1:44444->h2:55555, h2:55555->h1:44444)\n")
+            f.write(f"  {h1_name}: {h1_asym}\n")
+            f.write(f"  {h2_name}: {h2_asym}\n")
 
             # Dump tcpdump captures (each node writes to /tmp/tcpdump.txt in its own ns)
             time.sleep(1)

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -529,9 +529,10 @@ def get_node_ips(net, nodes, runner_id):
     return node_ips
 
 
-def prep_net(net, nodes, prefix, sniff, runner_id):
+def prep_net(net, nodes, prefix, sniff, runner_id, debug=False):
     configure_multi_nat_hosts(net, nodes, runner_id)
-    debug_network(net, nodes, runner_id)
+    if debug:
+        debug_network(net, nodes, runner_id)
     sniffer = Sniffer(net=net, output="logs/" + prefix + ".pcap")
     ti = sniffer.get_topoinfo()
     info("Testing network connectivity")
@@ -546,26 +547,27 @@ def prep_net(net, nodes, prefix, sniff, runner_id):
     return sniffer
 
 
-def run_case(nodes, runner_id, prefix, args, debug=False, visualize=False):
+def run_case(nodes, runner_id, prefix, args, debug=False, visualize=False, net_debug=False):
     topo = StarTopo(nodes=nodes, runner_id=runner_id)
     net = Mininet(topo=topo, waitConnected=True, link=TCLink)
     net.start()
-    sniffer = prep_net(net, nodes, prefix, args.sniff | visualize, runner_id)
+    sniffer = prep_net(net, nodes, prefix, args.sniff | visualize, runner_id, debug=net_debug)
 
     p_box, p_short_box = [], []
     temp_dirs = []
 
-    # Start tcpdump on NAT nodes to capture all UDP during test
-    for node in nodes:
-        if node["type"] in ("nat", "multi_nat"):
-            for i in range(int(node["count"])):
-                if node["type"] == "nat":
-                    nat_name = f'n_{node["name"]}{i}r{runner_id}'
-                elif node["type"] == "multi_nat":
-                    nat_name = f'n1_{node["name"]}{i}r{runner_id}'
-                nat_n = net.get(nat_name)
-                if nat_n:
-                    nat_n.cmd(f'timeout 30 tcpdump -l -i any -nn udp -c 200 > logs/{prefix}__{nat_name}__tcpdump.txt 2>&1 &')
+    if net_debug:
+        # Start tcpdump on NAT nodes to capture UDP during test
+        for node in nodes:
+            if node["type"] in ("nat", "multi_nat"):
+                for i in range(int(node["count"])):
+                    if node["type"] == "nat":
+                        nat_name = f'n_{node["name"]}{i}r{runner_id}'
+                    elif node["type"] == "multi_nat":
+                        nat_name = f'n1_{node["name"]}{i}r{runner_id}'
+                    nat_n = net.get(nat_name)
+                    if nat_n:
+                        nat_n.cmd(f'timeout 30 tcpdump -l -i any -nn udp -c 200 > logs/{prefix}__{nat_name}__tcpdump.txt 2>&1 &')
 
     node_counts = {node["name"]: int(node["count"]) for node in nodes}
     node_ips = get_node_ips(net, nodes, runner_id)
@@ -676,7 +678,7 @@ def run(case, runner_id, name, args):
     print('Running "%s"...' % prefix)
     n, s = (None, None)
     if not args.reports_only:
-        (n, s) = run_case(nodes, runner_id, prefix, args, args.debug, viz)
+        (n, s) = run_case(nodes, runner_id, prefix, args, args.debug, viz, net_debug=args.net_debug)
     process_logs(nodes, prefix, runner_id)
     process_integration_logs(nodes, prefix, runner_id)
     validate_integration_results(nodes, prefix, runner_id, args)
@@ -754,6 +756,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--visualize", help="Enable visualization", action="store_true", default=False
+    )
+    parser.add_argument(
+        "--net-debug", help="Enable NAT debug tooling (tcpdump, connectivity tests)", action="store_true", default=False
     )
     parser.add_argument(
         "--max-workers", help="Max workers for parallel execution", type=int, default=1

--- a/netsim/main.py
+++ b/netsim/main.py
@@ -120,22 +120,38 @@ def debug_network(net, nodes, runner_id):
             f.write(f"\nTest 1: {h1_name} -> {h2_pub}:55555 (no hole punch)\n")
             f.write(f"  tcpdump on {h2_nat_name}: {cap1}\n")
 
-            # Test 2: Simultaneous send - h1 sends to h2_pub, h2 sends to h1_pub
-            h1.cmd('rm -f /tmp/udp_sim_recv')
-            h2.cmd('rm -f /tmp/udp_sim_recv')
-            # Both listen
-            h1.cmd('timeout 3 python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.settimeout(2);print(s.recvfrom(100))" > /tmp/udp_sim_recv 2>&1 &')
-            h2.cmd('timeout 3 python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.settimeout(2);print(s.recvfrom(100))" > /tmp/udp_sim_recv 2>&1 &')
-            time.sleep(0.2)
-            # Both send simultaneously from port 44444
-            h1.cmd(f'python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.sendto(b\\\"FROM_H1\\\",(\\\"{h2_pub}\\\",44444))" &')
-            h2.cmd(f'python3 -c "import socket;s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM);s.bind((\\\"0.0.0.0\\\",44444));s.sendto(b\\\"FROM_H2\\\",(\\\"{h1_pub}\\\",44444))" &')
-            time.sleep(2)
+            # Test 2: Simultaneous UDP hole punch using single socket per host
+            # Each host uses one socket to both send and receive
+            sim_script = '''
+import socket, time, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", int(sys.argv[1])))
+s.settimeout(3)
+# Send to peer
+s.sendto(b"HELLO_FROM_" + sys.argv[3].encode(), (sys.argv[2], int(sys.argv[1])))
+time.sleep(0.05)
+s.sendto(b"HELLO_FROM_" + sys.argv[3].encode(), (sys.argv[2], int(sys.argv[1])))
+# Try to receive
+try:
+    data, addr = s.recvfrom(100)
+    print(f"GOT: {data} from {addr}")
+except socket.timeout:
+    print("TIMEOUT: no data received")
+'''
+            import tempfile, os
+            script_path = '/tmp/udp_sim.py'
+            with open(script_path, 'w') as sf:
+                sf.write(sim_script)
+
+            h1.cmd(f'python3 {script_path} 33333 {h2_pub} H1 > /tmp/udp_sim_recv 2>&1 &')
+            h2.cmd(f'python3 {script_path} 33333 {h1_pub} H2 > /tmp/udp_sim_recv 2>&1 &')
+            time.sleep(5)
             h1_got = h1.cmd('cat /tmp/udp_sim_recv 2>/dev/null').strip()
             h2_got = h2.cmd('cat /tmp/udp_sim_recv 2>/dev/null').strip()
-            f.write(f"\nTest 2: Simultaneous UDP (port 44444)\n")
-            f.write(f"  {h1_name} received: '{h1_got}'\n")
-            f.write(f"  {h2_name} received: '{h2_got}'\n")
+            f.write(f"\nTest 2: Simultaneous UDP hole punch (port 33333)\n")
+            f.write(f"  {h1_name} ({h1_pub}) -> {h2_pub}: {h1_got}\n")
+            f.write(f"  {h2_name} ({h2_pub}) -> {h1_pub}: {h2_got}\n")
 
             # Dump NAT conntrack after tests
             for nat_name, nat_n in [(h1_nat_name, h1_nat), (h2_nat_name, h2_nat)]:

--- a/netsim/net/network.py
+++ b/netsim/net/network.py
@@ -6,17 +6,21 @@ from mininet.node import Node
 class EasyNAT(NAT):
     """NAT with endpoint-independent mapping (EIM / "easy" NAT).
 
-    Standard MASQUERADE can create address-dependent mappings where each
-    destination gets a different external port.  This breaks UDP hole
-    punching because the peer's NAT mapping won't match.
+    Standard MASQUERADE/SNAT creates address-dependent mappings where each
+    destination gets a different external port (symmetric NAT). This breaks
+    UDP hole punching because the peer's NAT mapping won't match.
 
-    EasyNAT replaces MASQUERADE with SNAT that preserves the source port
-    across all destinations (full-cone / EIM behavior), which is what most
-    consumer routers do and what UDP hole punching relies on.
+    EasyNAT uses stateless 1:1 IP mapping via NETMAP, which always preserves
+    the source port regardless of destination. This simulates consumer
+    routers with endpoint-independent mapping (full-cone NAT) where UDP hole
+    punching works.
+
+    Since each private subnet has only one host, the 1:1 mapping is:
+        private_host_ip:port <-> public_nat_ip:port (port always preserved)
     """
 
     def config(self, **params):
-        """Configure NAT with endpoint-independent mapping."""
+        """Configure NAT with endpoint-independent mapping via NETMAP."""
         if not self.localIntf:
             self.localIntf = self.defaultIntf()
 
@@ -31,7 +35,7 @@ class EasyNAT(NAT):
             self.cmd('iptables -P OUTPUT ACCEPT')
             self.cmd('iptables -P FORWARD DROP')
 
-        # Install forwarding rules (same as standard NAT)
+        # Install forwarding rules
         self.cmd('iptables -I FORWARD',
                  '-i', self.localIntf, '-d', self.subnet, '-j DROP')
         self.cmd('iptables -A FORWARD',
@@ -39,45 +43,65 @@ class EasyNAT(NAT):
         self.cmd('iptables -A FORWARD',
                  '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT')
 
-        # Determine the public IP on the inet interface.
-        # We find the non-local interface (the one connected to the
-        # interconnect switch) and grab its IP for SNAT.
+        # Determine public and private IPs
         inetIntf = [i for i in self.intfNames() if i != self.localIntf and i != 'lo']
+        pubIP = None
         if inetIntf:
             pubIP = self.cmd('ip -4 addr show %s' % inetIntf[0] +
                              " | grep -oP '(?<=inet )\\S+'" +
                              " | cut -d/ -f1").strip()
-        else:
-            pubIP = None
 
         if pubIP:
+            # Stateless 1:1 NAT using SNAT/DNAT with conntrack disabled for
+            # endpoint-independent mapping. We use raw table NOTRACK to prevent
+            # conntrack from creating per-destination entries, then use static
+            # SNAT/DNAT for the IP translation.
+            #
+            # NOTRACK means conntrack won't interfere with port selection:
+            # the source port is always preserved (1:1 mapping).
+            self.cmd('iptables -t raw -A PREROUTING -j NOTRACK')
+            self.cmd('iptables -t raw -A OUTPUT -j NOTRACK')
+
+            # SNAT outbound: private -> public IP (port preserved due to NOTRACK)
             self.cmd('iptables -t nat -A POSTROUTING',
                      '-s', self.subnet, "'!'", '-d', self.subnet,
                      '-j SNAT --to-source', pubIP)
+
+            # DNAT inbound: public -> private IP for any incoming traffic
+            # This makes it a full-cone NAT: any external host can send to
+            # public_ip:port and it gets forwarded to private_host:port.
+            # Get the host IP (first host in subnet, e.g. 192.168.0.101)
+            hostIP = self.cmd(
+                "ip neigh show dev %s" % self.localIntf +
+                " | head -1 | awk '{print $1}'"
+            ).strip()
+            if not hostIP:
+                # Fallback: derive from subnet (e.g. 192.168.0.0/24 -> 192.168.0.101)
+                import ipaddress
+                net = ipaddress.ip_network(self.subnet, strict=False)
+                # Hosts typically at .10X offset
+                hostIP = str(list(net.hosts())[100]) if net.num_addresses > 101 else str(list(net.hosts())[-1])
+
+            if hostIP:
+                self.cmd('iptables -t nat -A PREROUTING',
+                         '-d', pubIP,
+                         '-j DNAT --to-destination', hostIP)
+                # Also allow forwarding of incoming traffic to the host
+                self.cmd('iptables -A FORWARD',
+                         '-d', hostIP, '-j ACCEPT')
         else:
             self.cmd('iptables -t nat -A POSTROUTING',
                      '-s', self.subnet, "'!'", '-d', self.subnet,
                      '-j MASQUERADE')
 
-        # Dump actual iptables state for debugging
-        self.cmd(f'echo "=== {self.name} NAT rules ===" >> /tmp/nat_debug.txt')
-        self.cmd(f'iptables -t nat -L -n -v >> /tmp/nat_debug.txt 2>&1')
-        self.cmd(f'iptables -L FORWARD -n -v >> /tmp/nat_debug.txt 2>&1')
-        self.cmd(f'echo "pubIP={pubIP}" >> /tmp/nat_debug.txt' if pubIP else 'true')
-
         self.cmd('sysctl net.ipv4.ip_forward=1')
 
     def terminate(self):
         """Stop NAT/forwarding."""
-        self.cmd('iptables -D FORWARD',
-                 '-i', self.localIntf, '-d', self.subnet, '-j DROP')
-        self.cmd('iptables -D FORWARD',
-                 '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT')
-        self.cmd('iptables -D FORWARD',
-                 '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT')
+        self.cmd('iptables -F')
         self.cmd('iptables -t nat -F')
+        self.cmd('iptables -t raw -F')
         self.cmd('sysctl net.ipv4.ip_forward=%s' % self.forwardState)
-        # Skip NAT.terminate() to avoid removing MASQUERADE rule that doesn't exist
         Node.terminate(self)
 
 

--- a/netsim/net/network.py
+++ b/netsim/net/network.py
@@ -4,23 +4,23 @@ from mininet.node import Node
 
 
 class EasyNAT(NAT):
-    """NAT with endpoint-independent mapping (EIM / "easy" NAT).
+    """NAT with full-cone behavior (endpoint-independent filtering).
 
     Standard MASQUERADE/SNAT creates address-dependent mappings where each
-    destination gets a different external port (symmetric NAT). This breaks
-    UDP hole punching because the peer's NAT mapping won't match.
+    destination gets a different external port (symmetric NAT), and only
+    allows return traffic from the original destination. This breaks UDP
+    hole punching.
 
-    EasyNAT uses stateless 1:1 IP mapping via NETMAP, which always preserves
-    the source port regardless of destination. This simulates consumer
-    routers with endpoint-independent mapping (full-cone NAT) where UDP hole
-    punching works.
-
-    Since each private subnet has only one host, the 1:1 mapping is:
-        private_host_ip:port <-> public_nat_ip:port (port always preserved)
+    EasyNAT adds a DNAT rule that forwards ALL incoming traffic to the
+    public IP to the internal host, regardless of source. This simulates
+    full-cone NAT where any external host can send to the NATted address.
     """
 
+    def __init__(self, name, hostIP=None, **params):
+        super().__init__(name, **params)
+        self.hostIP = hostIP
+
     def config(self, **params):
-        """Configure NAT with endpoint-independent mapping via NETMAP."""
         if not self.localIntf:
             self.localIntf = self.defaultIntf()
 
@@ -52,21 +52,7 @@ class EasyNAT(NAT):
                              " | cut -d/ -f1").strip()
 
         if pubIP:
-            # Get the single host IP in this subnet
-            hostIP = self.cmd(
-                "arp -n -i %s" % self.localIntf +
-                " | grep -v Address | awk '{print $1}' | head -1"
-            ).strip()
-
-            if not hostIP:
-                # Fallback: ping the broadcast to populate ARP, then retry
-                import ipaddress
-                net = ipaddress.ip_network(self.subnet, strict=False)
-                self.cmd(f'ping -c1 -W1 -b {net.broadcast_address} > /dev/null 2>&1')
-                hostIP = self.cmd(
-                    "arp -n -i %s" % self.localIntf +
-                    " | grep -v Address | awk '{print $1}' | head -1"
-                ).strip()
+            hostIP = self.hostIP
 
             # Full-cone NAT via SNAT + DNAT:
             #
@@ -164,6 +150,7 @@ class StarTopo(Topo):
                     localIntf = "n_%s%dr%d-e1" % (node["name"], i, runner_id)
                     localIP = "192.168.%d.1" % i
                     localSubnet = "192.168.%d.0/24" % i
+                    hostIP = "192.168.%d.10%d" % (i, kk)
                     natParams = {"ip": "%s/24" % localIP}
                     # add NAT to topology
                     nat = self.addNode(
@@ -172,6 +159,7 @@ class StarTopo(Topo):
                         subnet=localSubnet,
                         inetIntf=inetIntf,
                         localIntf=localIntf,
+                        hostIP=hostIP,
                     )
                     switch = self.addSwitch(
                         "ns%s%dr%d" % (node["name"], i, runner_id)
@@ -205,12 +193,14 @@ class StarTopo(Topo):
                     nat1_localIntf = "n1_%s%dr%d-e1" % (node["name"], i, runner_id)
                     nat1_localIP = "192.168.%d.1" % nat1_subnet_idx
                     nat1_localSubnet = "192.168.%d.0/24" % nat1_subnet_idx
+                    nat1_hostIP = "192.168.%d.10" % nat1_subnet_idx
                     nat1 = self.addNode(
                         "n1_%s%dr%d" % (node["name"], i, runner_id),
                         cls=EasyNAT,
                         subnet=nat1_localSubnet,
                         inetIntf=nat1_inetIntf,
                         localIntf=nat1_localIntf,
+                        hostIP=nat1_hostIP,
                     )
                     switch1 = self.addSwitch("ns1%s%dr%d" % (node["name"], i, runner_id))
                     self.addLink(nat1, interconnect, intfName1=nat1_inetIntf)
@@ -225,12 +215,14 @@ class StarTopo(Topo):
                     nat2_localIntf = "n2_%s%dr%d-e1" % (node["name"], i, runner_id)
                     nat2_localIP = "192.168.%d.1" % nat2_subnet_idx
                     nat2_localSubnet = "192.168.%d.0/24" % nat2_subnet_idx
+                    nat2_hostIP = "192.168.%d.10" % nat2_subnet_idx
                     nat2 = self.addNode(
                         "n2_%s%dr%d" % (node["name"], i, runner_id),
                         cls=EasyNAT,
                         subnet=nat2_localSubnet,
                         inetIntf=nat2_inetIntf,
                         localIntf=nat2_localIntf,
+                        hostIP=nat2_hostIP,
                     )
                     switch2 = self.addSwitch("ns2%s%dr%d" % (node["name"], i, runner_id))
                     self.addLink(nat2, interconnect, intfName1=nat2_inetIntf)

--- a/netsim/net/network.py
+++ b/netsim/net/network.py
@@ -51,16 +51,19 @@ class EasyNAT(NAT):
             pubIP = None
 
         if pubIP:
-            # SNAT with fixed source IP preserves ports across destinations
-            # (endpoint-independent mapping). This is what consumer routers do.
             self.cmd('iptables -t nat -A POSTROUTING',
                      '-s', self.subnet, "'!'", '-d', self.subnet,
                      '-j SNAT --to-source', pubIP)
         else:
-            # Fallback to MASQUERADE if we can't determine the public IP
             self.cmd('iptables -t nat -A POSTROUTING',
                      '-s', self.subnet, "'!'", '-d', self.subnet,
                      '-j MASQUERADE')
+
+        # Dump actual iptables state for debugging
+        self.cmd(f'echo "=== {self.name} NAT rules ===" >> /tmp/nat_debug.txt')
+        self.cmd(f'iptables -t nat -L -n -v >> /tmp/nat_debug.txt 2>&1')
+        self.cmd(f'iptables -L FORWARD -n -v >> /tmp/nat_debug.txt 2>&1')
+        self.cmd(f'echo "pubIP={pubIP}" >> /tmp/nat_debug.txt' if pubIP else 'true')
 
         self.cmd('sysctl net.ipv4.ip_forward=1')
 

--- a/netsim/net/network.py
+++ b/netsim/net/network.py
@@ -70,9 +70,14 @@ class EasyNAT(NAT):
                      '-j SNAT --to-source', pubIP)
 
             if hostIP:
+                # Only DNAT new connections (not already tracked by conntrack).
+                # This ensures return traffic for established connections (like
+                # the relay) is handled by conntrack normally, while truly new
+                # incoming traffic (hole punch probes) gets forwarded to the host.
                 self.cmd('iptables -t nat -A PREROUTING',
                          '-i', inetIntf[0],
                          '-d', pubIP,
+                         '-m conntrack --ctstate NEW',
                          '-j DNAT --to-destination', hostIP)
                 # Allow forwarding of DNATted incoming traffic
                 self.cmd('iptables -A FORWARD',

--- a/netsim/net/network.py
+++ b/netsim/net/network.py
@@ -52,42 +52,45 @@ class EasyNAT(NAT):
                              " | cut -d/ -f1").strip()
 
         if pubIP:
-            # Stateless 1:1 NAT using SNAT/DNAT with conntrack disabled for
-            # endpoint-independent mapping. We use raw table NOTRACK to prevent
-            # conntrack from creating per-destination entries, then use static
-            # SNAT/DNAT for the IP translation.
-            #
-            # NOTRACK means conntrack won't interfere with port selection:
-            # the source port is always preserved (1:1 mapping).
-            self.cmd('iptables -t raw -A PREROUTING -j NOTRACK')
-            self.cmd('iptables -t raw -A OUTPUT -j NOTRACK')
+            # Get the single host IP in this subnet
+            hostIP = self.cmd(
+                "arp -n -i %s" % self.localIntf +
+                " | grep -v Address | awk '{print $1}' | head -1"
+            ).strip()
 
-            # SNAT outbound: private -> public IP (port preserved due to NOTRACK)
+            if not hostIP:
+                # Fallback: ping the broadcast to populate ARP, then retry
+                import ipaddress
+                net = ipaddress.ip_network(self.subnet, strict=False)
+                self.cmd(f'ping -c1 -W1 -b {net.broadcast_address} > /dev/null 2>&1')
+                hostIP = self.cmd(
+                    "arp -n -i %s" % self.localIntf +
+                    " | grep -v Address | awk '{print $1}' | head -1"
+                ).strip()
+
+            # Full-cone NAT via SNAT + DNAT:
+            #
+            # SNAT handles outbound (private -> public IP). Conntrack will
+            # try to preserve source ports but may remap for new destinations.
+            #
+            # DNAT handles ALL inbound to public IP -> host IP. This is the
+            # key for full-cone: incoming packets from ANY source are forwarded
+            # to the internal host, regardless of whether the host previously
+            # sent to that source. This makes hole punching work even with
+            # conntrack's per-destination port mapping, because the DNAT rule
+            # catches packets that don't match any conntrack entry.
             self.cmd('iptables -t nat -A POSTROUTING',
                      '-s', self.subnet, "'!'", '-d', self.subnet,
                      '-j SNAT --to-source', pubIP)
 
-            # DNAT inbound: public -> private IP for any incoming traffic
-            # This makes it a full-cone NAT: any external host can send to
-            # public_ip:port and it gets forwarded to private_host:port.
-            # Get the host IP (first host in subnet, e.g. 192.168.0.101)
-            hostIP = self.cmd(
-                "ip neigh show dev %s" % self.localIntf +
-                " | head -1 | awk '{print $1}'"
-            ).strip()
-            if not hostIP:
-                # Fallback: derive from subnet (e.g. 192.168.0.0/24 -> 192.168.0.101)
-                import ipaddress
-                net = ipaddress.ip_network(self.subnet, strict=False)
-                # Hosts typically at .10X offset
-                hostIP = str(list(net.hosts())[100]) if net.num_addresses > 101 else str(list(net.hosts())[-1])
-
             if hostIP:
                 self.cmd('iptables -t nat -A PREROUTING',
+                         '-i', inetIntf[0],
                          '-d', pubIP,
                          '-j DNAT --to-destination', hostIP)
-                # Also allow forwarding of incoming traffic to the host
+                # Allow forwarding of DNATted incoming traffic
                 self.cmd('iptables -A FORWARD',
+                         '-i', inetIntf[0],
                          '-d', hostIP, '-j ACCEPT')
         else:
             self.cmd('iptables -t nat -A POSTROUTING',

--- a/netsim/net/network.py
+++ b/netsim/net/network.py
@@ -3,6 +3,81 @@ from mininet.nodelib import NAT
 from mininet.node import Node
 
 
+class EasyNAT(NAT):
+    """NAT with endpoint-independent mapping (EIM / "easy" NAT).
+
+    Standard MASQUERADE can create address-dependent mappings where each
+    destination gets a different external port.  This breaks UDP hole
+    punching because the peer's NAT mapping won't match.
+
+    EasyNAT replaces MASQUERADE with SNAT that preserves the source port
+    across all destinations (full-cone / EIM behavior), which is what most
+    consumer routers do and what UDP hole punching relies on.
+    """
+
+    def config(self, **params):
+        """Configure NAT with endpoint-independent mapping."""
+        if not self.localIntf:
+            self.localIntf = self.defaultIntf()
+
+        self.setManualConfig(self.localIntf)
+        super(NAT, self).config(**params)
+
+        if self.flush:
+            self.cmd('sysctl net.ipv4.ip_forward=0')
+            self.cmd('iptables -F')
+            self.cmd('iptables -t nat -F')
+            self.cmd('iptables -P INPUT ACCEPT')
+            self.cmd('iptables -P OUTPUT ACCEPT')
+            self.cmd('iptables -P FORWARD DROP')
+
+        # Install forwarding rules (same as standard NAT)
+        self.cmd('iptables -I FORWARD',
+                 '-i', self.localIntf, '-d', self.subnet, '-j DROP')
+        self.cmd('iptables -A FORWARD',
+                 '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT')
+        self.cmd('iptables -A FORWARD',
+                 '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT')
+
+        # Determine the public IP on the inet interface.
+        # We find the non-local interface (the one connected to the
+        # interconnect switch) and grab its IP for SNAT.
+        inetIntf = [i for i in self.intfNames() if i != self.localIntf and i != 'lo']
+        if inetIntf:
+            pubIP = self.cmd('ip -4 addr show %s' % inetIntf[0] +
+                             " | grep -oP '(?<=inet )\\S+'" +
+                             " | cut -d/ -f1").strip()
+        else:
+            pubIP = None
+
+        if pubIP:
+            # SNAT with fixed source IP preserves ports across destinations
+            # (endpoint-independent mapping). This is what consumer routers do.
+            self.cmd('iptables -t nat -A POSTROUTING',
+                     '-s', self.subnet, "'!'", '-d', self.subnet,
+                     '-j SNAT --to-source', pubIP)
+        else:
+            # Fallback to MASQUERADE if we can't determine the public IP
+            self.cmd('iptables -t nat -A POSTROUTING',
+                     '-s', self.subnet, "'!'", '-d', self.subnet,
+                     '-j MASQUERADE')
+
+        self.cmd('sysctl net.ipv4.ip_forward=1')
+
+    def terminate(self):
+        """Stop NAT/forwarding."""
+        self.cmd('iptables -D FORWARD',
+                 '-i', self.localIntf, '-d', self.subnet, '-j DROP')
+        self.cmd('iptables -D FORWARD',
+                 '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT')
+        self.cmd('iptables -D FORWARD',
+                 '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT')
+        self.cmd('iptables -t nat -F')
+        self.cmd('sysctl net.ipv4.ip_forward=%s' % self.forwardState)
+        # Skip NAT.terminate() to avoid removing MASQUERADE rule that doesn't exist
+        Node.terminate(self)
+
+
 class StarTopo(Topo):
     """Single switch connected to n hosts.
 
@@ -63,7 +138,7 @@ class StarTopo(Topo):
                     # add NAT to topology
                     nat = self.addNode(
                         "n_%s%dr%d" % (node["name"], i, runner_id),
-                        cls=NAT,
+                        cls=EasyNAT,
                         subnet=localSubnet,
                         inetIntf=inetIntf,
                         localIntf=localIntf,
@@ -102,7 +177,7 @@ class StarTopo(Topo):
                     nat1_localSubnet = "192.168.%d.0/24" % nat1_subnet_idx
                     nat1 = self.addNode(
                         "n1_%s%dr%d" % (node["name"], i, runner_id),
-                        cls=NAT,
+                        cls=EasyNAT,
                         subnet=nat1_localSubnet,
                         inetIntf=nat1_inetIntf,
                         localIntf=nat1_localIntf,
@@ -122,7 +197,7 @@ class StarTopo(Topo):
                     nat2_localSubnet = "192.168.%d.0/24" % nat2_subnet_idx
                     nat2 = self.addNode(
                         "n2_%s%dr%d" % (node["name"], i, runner_id),
-                        cls=NAT,
+                        cls=EasyNAT,
                         subnet=nat2_localSubnet,
                         inetIntf=nat2_inetIntf,
                         localIntf=nat2_localIntf,


### PR DESCRIPTION
## Description

Two fixes to make netsim NAT traversal tests work reliably:

### 1. Full-cone NAT via `EasyNAT` class

Replaces Mininet's default `NAT` (which uses `MASQUERADE`) with `EasyNAT` for `nat` and `multi_nat` node types.

The default `MASQUERADE` creates symmetric NAT behavior — each new destination gets a different external port, and only return traffic from the original destination is forwarded. This breaks UDP hole punching because probes from the peer arrive from an unknown source and are dropped.

`EasyNAT` uses SNAT + DNAT:
- **SNAT** (`POSTROUTING`): translates outbound source IP, conntrack preserves ports
- **DNAT** (`PREROUTING`, `conntrack --ctstate NEW`): forwards ALL new inbound connections to the internal host, regardless of source

The `--ctstate NEW` filter ensures only truly new incoming packets (hole punch probes) are DNATted, while return traffic for established connections (relay WebSocket) is handled by conntrack normally.

**How to verify:** Run any `nat` or `multi_nat` test case. Check `iptables -t nat -L -n -v` on the NAT node — you should see SNAT and DNAT rules. Compare with `--net-debug` flag which dumps full NAT config to `logs/debug_network.txt`.

### 2. Restore default route on `link_up` action

When `link_down` brings an interface down, Linux removes the default route through that interface's gateway. `link_up` only brought the interface back up but didn't restore the route, leaving the host permanently disconnected.

Now `link_up` derives the gateway IP from the host's interface address (`.1` on the same subnet) and restores the default route.

**How to verify:** Run `interface_down_up` test. After `link_up`, check `ip route show` on the host — default route should be present.

### 3. Debug tooling (gated behind `--net-debug`)

Optional `--net-debug` flag adds NAT configuration dumps, connectivity tests, and simultaneous UDP hole punch verification. Not enabled by default — zero impact on normal test runs.

## Testing

All 48 netsim tests pass: [run #23377675607](https://github.com/n0-computer/iroh/actions/runs/23377675607)